### PR TITLE
evaluate dom multiple times, fixes #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.4.0
+
+* Every URL you pass gets loaded twice. First *without Javascript* and then
+  *with JavaScript* (and waiting for network to be idle). These means the
+  minimal CSS will contain CSS that was necessary **before** the page is fully
+  loaded as well.
+  Also, the engine has entirely changed. Instead of evaluating the DOM inside
+  a page evaluation (the equivalent of running in the Web Console), puppeteer
+  is only used to 1) download relevant assets and 2) yield the DOM as a string
+  of HTML. Instead [cheerio](https://www.npmjs.com/package/cheerio) is used
+  to compare the CSS to the DOM.
+  [pull#53](https://github.com/peterbe/minimalcss/pull/53)
+
 # 0.3.1
 
 * Any errors raised internally by `document.querySelector()` are not

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ key is `urls`. Other optional options are:
 * `browser` - Instance of a [Browser](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser), which will be used instead of launching another one.
 * `userAgent` - specific user agent to use (string)
 
+## Warnings
+
+When `minimalcss` evaluate each CSS selector to decide whether to keep it
+or not, some selectors might not be parseable. Possibly, the CSS employs
+hacks for specific browsers that
+[cheerio](https://www.npmjs.com/package/cheerio) doesn't support. Or
+there might be CSS selectors that no browser or tool can understand
+(e.g a typo by the CSS author). If there's a problem parsing a CSS selector,
+the default is to swallow the exception and let the CSS selector stay.
+
+Also by default, all these warnings are hidden. To see them use the `--debug`
+flag (or `debug` API option). Then the CSS selector syntax errors are
+printed on `stderr`.
+
 ## Development
 
 We use ES6+ with jsdoc comments and TypeScript to do static type checking, like [puppeeteer does](https://github.com/GoogleChrome/puppeteer/pull/986/files).

--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ key is `urls`. Other optional options are:
   as an argument and returns boolean. If it returns true then given request
   will be aborted (skipped). Can be used to block requests to Google Analytics
   etc.
-* `loadimages` - If set to true, images will actually load.
+* `loadimages` - If set to `true`, images will actually load.
+* `withoutjavascript` - If set to `true` it will *skip* loading the page first
+  without JavaScript. By default `minimalcss` will evaluate the DOM as plain as
+  can be, and then with JavaScript enabled *and* waiting for network activity
+  to be idle.
 * `browser` - Instance of a [Browser](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser), which will be used instead of launching another one.
 * `userAgent` - specific user agent to use (string)
 

--- a/bin/minimalcss.js
+++ b/bin/minimalcss.js
@@ -18,7 +18,8 @@ const argv = minimist(args, {
     'version',
     'verbose',
     'debug',
-    'loadimages'
+    'loadimages',
+    'withoutjavascript'
   ],
   string: ['output', 'skip'],
   default: {
@@ -52,6 +53,8 @@ if (argv['help']) {
       '  --verbose                     Include a comment about the options and the date it was generated.\n' +
       '  --debug or -d                 Print all console logging during page rendering to stdout.\n' +
       '  --loadimages                  By default, all images are NOT downloaded. This reverses that.\n' +
+      '  --withoutjavascript           The CSS is evaluated against the DOM twice, first with no JavaScript, ' +
+      'then with. This disables the load without JavaScript.\n' +
       '  --skip                        String to match in URL to ignore download. Repeatable. E.g. --skip google-analyics.com\n' +
       '  --version or -v               Print minimalcss version.\n' +
       ''
@@ -74,6 +77,7 @@ const options = {
   urls: urls,
   debug: argv['debug'],
   loadimages: argv['loadimages'],
+  withoutjavascript: argv['withoutjavascript'],
   skippable: request => {
     let skips = argv['skip']
     if (!skips) {

--- a/examples/stages.css
+++ b/examples/stages.css
@@ -1,0 +1,19 @@
+.initial {
+    color: brown;
+}
+.loaded {
+    color: pink;
+    font-weight: bold;
+}
+
+.really-loaded {
+    color: orange;
+    font-style: italic;
+}
+
+.xhr-loaded {
+    color: purple;
+    font-size: 120%;
+}
+
+pre, p, abbr { padding-left: 10px; }

--- a/examples/stages.html
+++ b/examples/stages.html
@@ -15,14 +15,14 @@
     <img src="https://i.ytimg.com/vi/OStPrcq52ZA/maxresdefault.jpg"
      style="width: 100px" />
     <script>
-    $('p').addClass('loaded').text('LOADED');
+    $('p').removeClass('initial').addClass('loaded').text('LOADED');
 
     $(function() {
       $('p').addClass('really-loaded').text('FULLY LOADED');
 
       $.getJSON('https://autocompeter.com/v1?d=autocompeter.com&q=search')
       .done(function(response) {
-        $('p').removeClass('initial').addClass('xhr-loaded')
+        $('p').removeClass('loaded').addClass('xhr-loaded')
         .text('XHR LOADED ' + response.results.length + ' ITEMS WITH XHR');
       });
     });

--- a/examples/stages.html
+++ b/examples/stages.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link href="stages.css" rel="stylesheet">
+  </head>
+  <body>
+    <p class="initial">
+      This paragraph starts out black on white until the CSS loads.<br />
+      Then it becomes BROWN.<br />
+      After jQuery has been downloaded, it changes to PINK and BOLD.<br />
+      Once the DOMContentLoaded fires, it changes to ORANGE and italic.
+    </p>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <img src="https://i.ytimg.com/vi/OStPrcq52ZA/maxresdefault.jpg"
+     style="width: 100px" />
+    <script>
+    $('p').addClass('loaded').text('LOADED');
+
+    $(function() {
+      $('p').addClass('really-loaded').text('FULLY LOADED');
+
+      $.getJSON('https://autocompeter.com/v1?d=autocompeter.com&q=search')
+      .done(function(response) {
+        $('p').removeClass('initial').addClass('xhr-loaded')
+        .text('XHR LOADED ' + response.results.length + ' ITEMS WITH XHR');
+      });
+    });
+
+
+
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "url": "https://github.com/peterbe/minimalcss/issues"
   },
   "dependencies": {
-    "css-tree": "1.0.0-alpha25",
-    "csso": "3.3.1",
+    "cheerio": "1.0.0-rc.2",
+    "css-tree": "1.0.0-alpha.26",
+    "csso": "3.4.0",
     "filesize": "^3.5.10",
     "minimist": "^1.2.0",
     "puppeteer": "^0.13.0"
@@ -33,7 +34,7 @@
     "@types/node": "^8.0.46",
     "@types/puppeteer": "^0.12.0",
     "husky": "^0.14.3",
-    "lint-staged": "^4.2.1",
+    "lint-staged": "^5.0.0",
     "prettier": "^1.8.2",
     "typescript": "^2.7.0-dev.20171025"
   },

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
     "cheerio": "1.0.0-rc.2",
     "css-tree": "1.0.0-alpha.26",
     "csso": "3.4.0",
-    "filesize": "^3.5.10",
+    "filesize": "^3.5.11",
     "minimist": "^1.2.0",
     "puppeteer": "^0.13.0"
   },
   "devDependencies": {
-    "@types/node": "^8.0.46",
-    "@types/puppeteer": "^0.12.0",
+    "@types/node": "^8.0.57",
+    "@types/puppeteer": "^0.13.7",
     "husky": "^0.14.3",
-    "lint-staged": "^5.0.0",
-    "prettier": "^1.8.2",
+    "lint-staged": "^6.0.0",
+    "prettier": "^1.9.1",
     "typescript": "^2.7.0-dev.20171025"
   },
   "scripts": {

--- a/src/run.js
+++ b/src/run.js
@@ -12,7 +12,7 @@ const url = require('url')
 
 /**
  *
- * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string }} options
+ * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean }} options
  * @return Promise<{ finalCss: string, stylesheetAstObjects: any, stylesheetContents: string }>
  */
 const minimalcss = async options => {
@@ -27,7 +27,6 @@ const minimalcss = async options => {
 
   const stylesheetAstObjects = {}
   const stylesheetContents = {}
-  const allCleaned = []
   const doms = []
   const allHrefs = new Set()
 

--- a/src/run.js
+++ b/src/run.js
@@ -5,6 +5,8 @@ const puppeteer = require('puppeteer')
 const csso = require('csso')
 // @ts-ignore
 const csstree = require('css-tree')
+// @ts-ignore
+const cheerio = require('cheerio')
 const collectImportantComments = require('./utils').collectImportantComments
 const url = require('url')
 
@@ -25,6 +27,9 @@ const minimalcss = async options => {
   const stylesheetAstObjects = {}
   const stylesheetContents = {}
   const allCleaned = []
+  const doms = []
+  const allHrefs = new Set()
+
   // Note! This opens one URL at a time synchronous
   for (let i = 0; i < urls.length; i++) {
     const pageUrl = urls[i]
@@ -35,13 +40,16 @@ const minimalcss = async options => {
     }
 
     // A must or else you can't do console.log from within page.evaluate()
-    page.on('console', (...args) => {
+    page.on('console', msg => {
       if (debug) {
-        console.log(...args)
+        // console.log(...(msg.args))
+        // console.log(msg.args)
+        for (let i = 0; i < msg.args.length; ++i) {
+          console.log(`${i}: ${msg.args[i]}`)
+        }
       }
     })
 
-    // XXX Isn't there a better way to enable options like this?
     await page.setRequestInterception(true)
     page.on('request', request => {
       if (/data:image\//.test(request.url)) {
@@ -119,204 +127,132 @@ const minimalcss = async options => {
     page.on('pageerror', error => {
       throw error
     })
-
-    const response = await page.goto(pageUrl, { waitUntil: 'networkidle2' })
+    // First goto the page and evaluate it on the 'load' event.
+    let response = await page.goto(pageUrl, { waitUntil: 'load' })
     if (!response.ok) {
       throw new Error(`${response.status} on ${pageUrl}`)
     }
-
-    const cleaned = await page.evaluate(
-      (stylesheetAstObjects, debug) => {
-        const cleaner = (ast, callback) => {
-          const selectorToString = children => {
-            let str = ''
-            children.forEach(child => {
-              if (child.type === 'IdSelector') {
-                str += '#' + child.name
-              } else if (child.type === 'ClassSelector') {
-                str += '.' + child.name
-              } else if (child.type === 'TypeSelector') {
-                str += child.name
-              } else if (child.type === 'WhiteSpace') {
-                str += ' '
-              } else if (child.type === 'Combinator') {
-                str += ` ${child.name} `
-              } else if (child.type === 'AttributeSelector') {
-                if (child.value === null) {
-                  str += `[${child.name.name}]`
-                } else if (child.value.value) {
-                  str += `[${child.name.name}${child.operator}${
-                    child.value.value
-                  }]`
-                } else {
-                  str += `[${child.name.name}${child.operator}${
-                    child.value.name
-                  }]`
-                }
-              } else if (child.type === 'PseudoElementSelector') {
-                str += `::${child.name}`
-                if (child.children) {
-                  str += selectorToString(child.children)
-                }
-              } else if (child.type === 'PseudoClassSelector') {
-                str += `:${child.name}`
-                if (child.children) {
-                  str += selectorToString(child.children)
-                }
-              } else if (child.type === 'SelectorList') {
-                str += selectorToString(child.children)
-              } else if (child.type === 'Selector') {
-                str += `(${selectorToString(child.children)})`
-              } else if (child.type === 'Nth') {
-                str += `(${child.nth.name})`
-              } else if (child.type === 'Identifier') {
-                str += `(${child.name})`
-              } else {
-                // console.error(child);
-                // console.error(children);
-                console.log('TYPE??', child.type, child)
-                console.log(child)
-                console.dir(children)
-                throw new Error(child.type)
-              }
-            })
-            if (str.indexOf('[object Object]') > -1) {
-              console.log(str)
-              console.log(children)
-              throw new Error('selector string became [object Object]!')
-            }
-            if (str === '') {
-              console.log(children)
-              throw new Error('selector string became an empty string!')
-            }
-            return str
-          }
-
-          const decisionsCache = {}
-
-          const clean = (children, callback) => {
-            return children.filter(child => {
-              if (child.type === 'Rule') {
-                const values = child.prelude.value.split(',').map(x => x.trim())
-                const keepValues = values.filter(selectorString => {
-                  if (decisionsCache[selectorString] !== undefined) {
-                    return decisionsCache[selectorString]
-                  }
-                  const keep = callback(selectorString)
-                  decisionsCache[selectorString] = keep
-                  return keep
-                })
-                if (keepValues.length) {
-                  // re-write the selector value
-                  child.prelude.value = keepValues.join(', ')
-                  return true
-                } else {
-                  return false
-                }
-                // } else if (
-                //   child.type === 'Atrule' &&
-                //   child.prelude &&
-                //   child.expression.type === 'MediaQueryList'
-                // ) {
-              } else if (child.type === 'Atrule' && child.name === 'media') {
-                // recurse
-                child.block.children = clean(child.block.children, callback)
-                return child.block.children.length > 0
-              } else {
-                // Things like comments
-                // console.log(child.type);
-                // console.dir(child)
-              }
-              // The default is to keep it.
-              return true
-            })
-          }
-
-          ast.children = clean(ast.children, callback)
-          return ast
-        }
-
-        const objsCleaned = {}
-
-        const DEAD_OBVIOUS = new Set(['*', 'body', 'html'])
-
-        const links = Array.from(document.querySelectorAll('link'))
-        links
-          .filter(link => {
-            return (
-              link.href &&
-              (link.rel === 'stylesheet' ||
-                link.href.toLowerCase().endsWith('.css')) &&
-              !link.href.toLowerCase().startsWith('blob:') &&
-              link.media !== 'print'
-            )
-          })
-          .forEach(stylesheet => {
-            if (!stylesheetAstObjects[stylesheet.href]) {
-              throw new Error(`${stylesheet.href} not in stylesheetAstObjects!`)
-            }
-            if (!Object.keys(stylesheetAstObjects[stylesheet.href]).length) {
-              // If the 'stylesheetAstObjects[stylesheet.href]' thing is an
-              // empty object, simply skip this link.
-              return
-            }
-            const obj = stylesheetAstObjects[stylesheet.href]
-            objsCleaned[stylesheet.href] = cleaner(obj, selector => {
-              // Here's the crucial part. Decide whether to keep the selector
-
-              if (DEAD_OBVIOUS.has(selector)) {
-                // low hanging fruit easy ones
-                return true
-              }
-
-              // Avoid doing a querySelector on hacks that will fail
-              if (/:-(ms|moz)-/.test(selector)) {
-                // eg. '.form-control:-ms-input-placeholder'
-                return true
-              }
-
-              try {
-                const keep = !!document.querySelector(selector)
-                return keep
-              } catch (ex) {
-                const exception = ex.toString()
-                if (debug) {
-                  throw new Error(
-                    `Unable to querySelector('${selector}') [${exception}]`
-                  )
-                } else {
-                  // Better safe than sorry
-                  return true
-                }
-              }
-            })
-          })
-        return Promise.resolve(objsCleaned)
-      },
-      stylesheetAstObjects,
-      debug
+    const htmlLoad = await page.evaluate(
+      () => document.documentElement.outerHTML
     )
-    allCleaned.push(cleaned)
+    doms.push(cheerio.load(htmlLoad))
+    // Second, goto the page and evaluate it on the 'networkidle2' event.
+    // This gives the page a chance to load any <script defer src="...">
+    // and even some JS that does XHR requests right after load.
+    response = await page.goto(pageUrl, {
+      waitUntil: ['domcontentloaded', 'networkidle2']
+    })
+    if (!response.ok) {
+      throw new Error(`${response.status} on ${pageUrl} (second time)`)
+    }
+    const evalNetworkIdle = await page.evaluate(() => {
+      // The reason for NOT using a Set here is that that might not be
+      // supported in ES5.
+      const hrefs = []
+      // Loop over all the 'link' elements in the document and
+      // for each, collect the URL of all the ones we're going to assess.
+      Array.from(document.querySelectorAll('link')).forEach(link => {
+        if (
+          link.href &&
+          (link.rel === 'stylesheet' ||
+            link.href.toLowerCase().endsWith('.css')) &&
+          !link.href.toLowerCase().startsWith('blob:') &&
+          link.media !== 'print'
+        ) {
+          // if (!stylesheetAstObjects[link.href]) {
+          //   throw new Error(`${link.href} not in stylesheetAstObjects!`)
+          // }
+          // if (!Object.keys(stylesheetAstObjects[link.href]).length) {
+          //   // If the 'stylesheetAstObjects[link.href]' thing is an
+          //   // empty object, simply skip this link.
+          //   return
+          // }
+          hrefs.push(link.href)
+        }
+      })
+      return {
+        html: document.documentElement.outerHTML,
+        hrefs
+      }
+    })
+
+    const htmlNetworkIdle = evalNetworkIdle.html
+    if (htmlNetworkIdle !== htmlLoad) {
+      // Basically, after waiting for the network, the DOM *did* change.
+      doms.push(cheerio.load(htmlNetworkIdle))
+    }
+    evalNetworkIdle.hrefs.forEach(href => {
+      allHrefs.add(href)
+    })
+
+    // We can close the browser now that all URLs have been opened.
+    if (!options.browser) {
+      browser.close()
+    }
   }
+  // All URLs have been opened, and we now have multiple DOM objects.
 
-  // We can close the browser now that all URLs have been opened.
-  if (!options.browser) {
-    browser.close()
-  }
+  // Now, let's loop over ALL links and process their ASTs compared to
+  // the DOMs.
+  const objsCleaned = {}
+  const decisionsCache = {}
+  const DEAD_OBVIOUS = new Set(['*', 'body', 'html'])
+  allHrefs.forEach(href => {
+    const ast = stylesheetAstObjects[href]
+    const clean = (children, callback) => {
+      return children.filter(child => {
+        if (child.type === 'Rule') {
+          const values = child.prelude.value.split(',').map(x => x.trim())
+          const keepValues = values.filter(selectorString => {
+            if (decisionsCache[selectorString] !== undefined) {
+              return decisionsCache[selectorString]
+            }
+            const keep = callback(selectorString)
+            decisionsCache[selectorString] = keep
+            return keep
+          })
+          if (keepValues.length) {
+            // re-write the selector value
+            child.prelude.value = keepValues.join(', ')
+            return true
+          } else {
+            return false
+          }
+          // } else if (
+          //   child.type === 'Atrule' &&
+          //   child.prelude &&
+          //   child.expression.type === 'MediaQueryList'
+          // ) {
+        } else if (child.type === 'Atrule' && child.name === 'media') {
+          // recurse
+          child.block.children = clean(child.block.children, callback)
+          return child.block.children.length > 0
+        } else {
+          // Things like comments
+          // console.log(child.type);
+          // console.dir(child)
+        }
+        // The default is to keep it.
+        return true
+      })
+    }
 
-  // The rest is post-processing all the CSS that was cleaned.
-
-  const allCombinedCss = allCleaned
-    .map(cleaned => {
-      const combinedCss = Object.keys(cleaned)
-        .map(cssUrl => {
-          const obj = cleaned[cssUrl]
-          const cleanedAst = csstree.fromPlainObject(obj)
-          const cleanedCss = csstree.translate(cleanedAst)
-          return cleanedCss
-        })
-        .join('\n')
-      return combinedCss
+    ast.children = clean(ast.children, selectorString => {
+      // Here's the crucial part. Decide whether to keep the selector
+      if (DEAD_OBVIOUS.has(selectorString)) {
+        // low hanging fruit easy ones.
+        return true
+      }
+      // Find at least 1 DOM that contains an object that matches
+      // this selector string.
+      return doms.some(dom => dom(selectorString).length > 0)
+    })
+    objsCleaned[href] = ast
+  })
+  // Every unique URL in every <link> tag has been checked.
+  const allCombinedCss = Object.keys(objsCleaned)
+    .map(cssUrl => {
+      return csstree.translate(csstree.fromPlainObject(objsCleaned[cssUrl]))
     })
     .join('\n')
 

--- a/src/run.js
+++ b/src/run.js
@@ -142,7 +142,18 @@ const minimalcss = async options => {
       await page.setJavaScriptEnabled(true)
     }
 
-    // Third, goto the page and evaluate it on the 'networkidle2' event.
+    // XXX There is another use case *between* the pure DOM (without any
+    // javascript) and after the network is idle.
+    // For example, any CSSOM that is *made by javascript* but goes away
+    // after all XHR is finished loading.
+    // What we can do is do that lookup here using...
+    //    response = await page.goto(pageUrl, {
+    //        waitUntil: ['domcontentloaded']
+    //    })
+    // And add that to the list of DOMs.
+    // This will slow down the whole processing marginally.
+
+    // Second, goto the page and evaluate it on the 'networkidle2' event.
     // This gives the page a chance to load any <script defer src="...">
     // and even some JS that does XHR requests right after load.
     response = await page.goto(pageUrl, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,4 +29,22 @@ const collectImportantComments = css => {
   return combined.join('\n')
 }
 
-module.exports = { collectImportantComments }
+/**
+ * Reduce a CSS selector to be without any pseudo class parts.
+ * For example, from `a:hover` return `a`. And from `input::-moz-focus-inner`
+ * to `input`.
+ * Also, more advanced ones like `a[href^="javascript:"]:after` to
+ * `a[href^="javascript:"]`.
+ * The last example works too if the input was `a[href^='javascript:']:after`
+ * instead (using ' instead of ").
+ *
+ * @param {string} selector
+ * @return {string}
+ */
+const reduceCSSSelector = selector => {
+  return selector.split(
+    /:(?=([^"'\\]*(\\.|["']([^"'\\]*\\.)*[^"'\\]*['"]))*[^"']*$)/g
+  )[0]
+}
+
+module.exports = { collectImportantComments, reduceCSSSelector }

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,10 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+any-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
+
 app-root-path@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
@@ -53,6 +57,10 @@ argparse@^1.0.7:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -78,6 +86,17 @@ chalk@^2.0.1, chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+cheerio@1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 ci-info@^1.0.0:
   version "1.1.1"
@@ -134,18 +153,14 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+cosmiconfig@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
   dependencies:
-    graceful-fs "^4.1.2"
-    js-yaml "^3.4.3"
-    minimist "^1.2.0"
-    object-assign "^4.0.1"
-    os-homedir "^1.0.1"
-    parse-json "^2.2.0"
-    pinkie-promise "^2.0.0"
-    require-from-string "^1.1.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^3.0.0"
+    require-from-string "^2.0.1"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -155,6 +170,22 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-tree@1.0.0-alpha.26:
+  version "1.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.26.tgz#690bee3458fb5b6b7000553983c8c30876da0b3e"
+  dependencies:
+    mdn-data "^1.0.0"
+    source-map "^0.5.3"
+
 css-tree@1.0.0-alpha25:
   version "1.0.0-alpha25"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha25.tgz#1bbfabfbf6eeef4f01d9108ff2edd0be2fe35597"
@@ -162,9 +193,13 @@ css-tree@1.0.0-alpha25:
     mdn-data "^1.0.0"
     source-map "^0.5.3"
 
-csso@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-3.3.1.tgz#e069a8f52adcf53685a8a7374256ccbc22c6ce3e"
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+csso@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-3.4.0.tgz#57b27ef553cccbf5aa964c641748641e9af113f3"
   dependencies:
     css-tree "1.0.0-alpha25"
 
@@ -184,11 +219,54 @@ debug@^2.4.1, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
-error-ex@^1.2.0:
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -254,6 +332,10 @@ filesize@^3.5.10:
   version "3.5.10"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -277,10 +359,6 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.2:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -290,6 +368,17 @@ has-ansi@^2.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 https-proxy-agent@^2.1.0:
   version "2.1.0"
@@ -323,7 +412,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -336,6 +425,10 @@ is-ci@^1.0.10:
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
     ci-info "^1.0.0"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -362,6 +455,12 @@ is-glob@^4.0.0:
 is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
+  dependencies:
+    symbol-observable "^0.2.2"
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -396,7 +495,7 @@ jest-validate@^21.1.0:
     leven "^2.1.0"
     pretty-format "^21.2.1"
 
-js-yaml@^3.4.3:
+js-yaml@^3.9.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -407,23 +506,27 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
-lint-staged@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.3.0.tgz#ed0779ad9a42c0dc62bb3244e522870b41125879"
+lint-staged@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-5.0.0.tgz#f1c670e03e2fdf3f3d0eb81f72d3bcf658770e54"
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
     commander "^2.11.0"
-    cosmiconfig "^1.1.0"
+    cosmiconfig "^3.1.0"
+    dedent "^0.7.0"
     execa "^0.8.0"
+    find-parent-dir "^0.3.0"
     is-glob "^4.0.0"
     jest-validate "^21.1.0"
-    listr "^0.12.0"
+    listr "^0.13.0"
     lodash "^4.17.4"
     log-symbols "^2.0.0"
     minimatch "^3.0.0"
     npm-which "^3.0.1"
     p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
     staged-git-files "0.0.4"
     stringify-object "^3.2.0"
 
@@ -431,9 +534,9 @@ listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
 
-listr-update-renderer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+listr-update-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"
@@ -453,28 +556,29 @@ listr-verbose-renderer@^0.4.0:
     date-fns "^1.27.2"
     figures "^1.7.0"
 
-listr@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+listr@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.13.0.tgz#20bb0ba30bae660ee84cc0503df4be3d5623887d"
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"
     figures "^1.7.0"
     indent-string "^2.1.0"
+    is-observable "^0.2.0"
     is-promise "^2.1.0"
     is-stream "^1.1.0"
     listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.2.0"
+    listr-update-renderer "^0.4.0"
     listr-verbose-renderer "^0.4.0"
     log-symbols "^1.0.2"
     log-update "^1.0.2"
     ora "^0.2.3"
     p-map "^1.1.1"
-    rxjs "^5.0.0-beta.11"
-    stream-to-observable "^0.1.0"
+    rxjs "^5.4.2"
+    stream-to-observable "^0.2.0"
     strip-ansi "^3.0.1"
 
-lodash@^4.17.4:
+lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -564,6 +668,12 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -591,10 +701,6 @@ ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-os-homedir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -603,15 +709,25 @@ p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
-parse-json@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+parse-json@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
   dependencies:
-    error-ex "^1.2.0"
+    error-ex "^1.3.1"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
 path-key@^2.0.0:
   version "2.0.1"
@@ -621,15 +737,9 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 prettier@^1.8.2:
   version "1.8.2"
@@ -671,7 +781,7 @@ puppeteer@^0.13.0:
     rimraf "^2.6.1"
     ws "^3.0.0"
 
-readable-stream@^2.2.2:
+readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -689,9 +799,9 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-require-from-string@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -706,7 +816,7 @@ rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rxjs@^5.0.0-beta.11:
+rxjs@^5.4.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
   dependencies:
@@ -746,9 +856,11 @@ staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
 
-stream-to-observable@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+stream-to-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
+  dependencies:
+    any-observable "^0.2.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -795,6 +907,10 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
 symbol-observable@^1.0.1:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,23 @@
 # yarn lockfile v1
 
 
-"@types/node@*", "@types/node@^8.0.46":
+"@types/events@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
+
+"@types/node@*":
   version "8.0.46"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.46.tgz#6e1766b2d0ed06631d5b5f87bb8e72c8dbb6888e"
 
-"@types/puppeteer@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-0.12.0.tgz#ba48be19d08abf7774192304a5cae5ce8e519481"
+"@types/node@^8.0.57":
+  version "8.0.57"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.57.tgz#e5d8b4dc112763e35cfc51988f4f38da3c486d99"
+
+"@types/puppeteer@^0.13.7":
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-0.13.7.tgz#6a6aff56913bbbdcfe5f1201e43a66de341ef152"
   dependencies:
+    "@types/events" "*"
     "@types/node" "*"
 
 agent-base@^4.1.0:
@@ -219,6 +228,12 @@ debug@^2.4.1, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -328,9 +343,9 @@ figures@^1.7.0:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
 
-filesize@^3.5.10:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
+filesize@^3.5.11:
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -506,14 +521,15 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
-lint-staged@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-5.0.0.tgz#f1c670e03e2fdf3f3d0eb81f72d3bcf658770e54"
+lint-staged@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-6.0.0.tgz#7ab7d345f2fe302ff196f1de6a005594ace03210"
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
     commander "^2.11.0"
     cosmiconfig "^3.1.0"
+    debug "^3.1.0"
     dedent "^0.7.0"
     execa "^0.8.0"
     find-parent-dir "^0.3.0"
@@ -741,9 +757,9 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
-prettier@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+prettier@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.1.tgz#41638a0d47c1efbd1b7d5a742aaa5548eab86d70"
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
Hey @stereobooster What do you think about this?
The diff is really large so it might be hard to see what's going on. But basically...

It does this:
```javascript
const browser = await puppeteer.launch({})
for (url in urls) {
  const page = await browser.newPage()
  await page.goto(url)
  const html1 = await page.evaluate(() => {
    return document.documentElement.outerHTML;
  })
  await page.goto(url, {waitUntil: 'networkidle2'})
  const html2 = await page.evaluate(() => {
    return document.documentElement.outerHTML;
  }) 
  ...Note that we have two strings of HTML called 'html1' and 'html2'
}
browser.close()
```
So, in the `page.evaluate` the only thing we do is that we send the `document.body` DOM element as a string in HTML. 
Once that's done, use [cheerio](https://www.npmjs.com/package/cheerio) to parse the HTML strings (if you're not familiar with cheerio, it's basically like jQuery but for node)

Once all CSS and all HTML has been downloaded you're outside Puppeteer and can post process it all in full Node without having to do this work inside the `page.evaluate` callback. 