### PR TITLE
Testcase for css-in-js

### DIFF
--- a/examples/css-in-js.css
+++ b/examples/css-in-js.css
@@ -1,0 +1,1 @@
+.external { color: red }

--- a/examples/css-in-js.html
+++ b/examples/css-in-js.html
@@ -6,6 +6,16 @@
     <style type="text/css">
       .inline { color: red }
     </style>
+  </head>
+  <body>
+    <p class="external">external</p>
+    <p class="inline">inline</p>
+    <p class="cssinjs1">cssinjs1</p>
+    <p class="cssinjs2">cssinjs2</p>
+    <p class="cssinjs3">cssinjs3</p>
+    <p class="cssinjs4">cssinjs4</p>
+    <p class="cssinjs5">cssinjs5</p>
+    <p class="cssinjs6">cssinjs8</p>
     <script type="text/javascript">
       (() => {
         const css = '.cssinjs1 { color: red; }',
@@ -33,11 +43,18 @@
         sheet.insertRule(css, sheet.cssRules.length)
       })();
     </script>
-  </head>
-  <body>
-    <p class="external">external</p>
-    <p class="inline">inline</p>
-    <p class="cssinjs1">cssinjs1</p>
-    <p class="cssinjs2">cssinjs2</p>
+    <script type="text/javascript">
+      const blob = new Blob(['.cssinjs3 { color: red; }'], {type: 'text/css'});
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = window.URL.createObjectURL(blob);
+      const head = document.head || document.getElementsByTagName('head')[0];
+      head.appendChild(link);
+    </script>
+    <script type="text/javascript">
+      document.querySelector('.cssinjs4').style.cssText = "color: red";
+      document.querySelector('.cssinjs5').setAttribute("style", "color:red");
+      document.querySelector('.cssinjs6').style.color = "red";
+    </script>
   </body>
 </html>

--- a/examples/css-in-js.html
+++ b/examples/css-in-js.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link href="css-in-js.css" rel=stylesheet>
+    <style type="text/css">
+      .inline { color: red }
+    </style>
+    <script type="text/javascript">
+      (() => {
+        const css = '.cssinjs1 { color: red; }',
+            head = document.head || document.getElementsByTagName('head')[0],
+            style = document.createElement('style');
+
+        style.type = 'text/css';
+        if (style.styleSheet){
+          style.styleSheet.cssText = css;
+        } else {
+          style.appendChild(document.createTextNode(css));
+        }
+
+        head.appendChild(style);
+      })();
+    </script>
+    <script type="text/javascript">
+      (() => {
+        const css = '.cssinjs2 { color: red; }',
+            head = document.head || document.getElementsByTagName('head')[0],
+            style = document.createElement('style');
+        head.appendChild(style);
+
+        const sheet = style.sheet;
+        sheet.insertRule(css, sheet.cssRules.length)
+      })();
+    </script>
+  </head>
+  <body>
+    <p class="external">external</p>
+    <p class="inline">inline</p>
+    <p class="cssinjs1">cssinjs1</p>
+    <p class="cssinjs2">cssinjs2</p>
+  </body>
+</html>


### PR DESCRIPTION
Related to https://github.com/stereobooster/react-snap/issues/76

All possible examples of inserting CSS into the document. As of now it only tracks external files

```
./bin/minimalcss.js http://127.0.0.1:8080/css-in-js.html
.external{color:red}
```

The question is: should `minimalcss` track css-in-js generated css or not. ~~`minimalcss` should not take into account existing style tags (`.inline` in given example).  They can be tracked at first load (without JS).~~

UPD: if we treat `minimalcss` as a tool which returns set of css rules required to render current page it doesn't matter where css comes from. It would be nice to have config to specify what to take into account: external (e.g. `<link>`), dynamic styles, all available styles. WDYT?
