### PR TITLE
Rework to use AST as much as possible and latests csstree & csso

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "cheerio": "1.0.0-rc.2",
-    "css-tree": "1.0.0-alpha.26",
-    "csso": "3.4.0",
+    "css-tree": "1.0.0-alpha.27",
+    "csso": "~3.5.0",
     "filesize": "^3.5.11",
     "minimist": "^1.2.0",
     "puppeteer": "^0.13.0"

--- a/src/run.js
+++ b/src/run.js
@@ -15,56 +15,31 @@ const url = require('url')
  * @return Object
  */
 const postProcessKeyframes = ast => {
-  const activeAnimationNames = new Set()
   // First walk the AST to know which animations are ever mentioned
-  // by the remaining selectors.
-  csstree.walk(ast, node => {
-    if (node.type === 'Declaration') {
-      if (
-        node.property.search(/\banimation$/i) > -1 ||
-        node.property.search(/\banimation-name$/i) > -1
-      ) {
-        // E.g. `animation: thename infinite 5s linear`
-        // Or `animation-name: thename`
-        let firstName = false
-        node.value.children.each(child => {
-          if (child.type === 'Identifier' && child.name && !firstName) {
-            activeAnimationNames.add(child.name.toLowerCase())
-            firstName = true
-          }
-        })
+  // by the remaining rules.
+  const activeAnimationNames = new Set(
+    csstree.lexer
+      .findAllFragments(ast, 'Type', 'keyframes-name')
+      .map(entry => csstree.generate(entry.nodes.first()))
+  )
+
+  // This is the function we use to filter @keyframes atrules out.
+  csstree.walk(ast, {
+    visit: 'Atrule',
+    enter: (node, item, list) => {
+      if (csstree.keyword(node.name).basename === 'keyframes') {
+        if (!activeAnimationNames.has(csstree.generate(node.prelude))) {
+          list.remove(item)
+        }
       }
     }
   })
-  // This is the function we use to filter children out.
-  const cleanChildren = (children, callback) => {
-    return children.filter(child => {
-      // The reason for the '\bkeyframes$' regex here is because you might
-      // have CSS that looks like this:
-      //   @-webkit-keyframes progress-bar-stripes {
-      //     ...
-      //   }
-      // Bootstrap v3 has this for example.
-      if (child.type === 'Atrule' && child.name.search(/\bkeyframes$/i) > -1) {
-        const keyframeName = child.prelude.children[0].name
-        return callback(keyframeName)
-      }
-      return true
-    })
-  }
-  // First convert the AST object into a plain object so we can mutate
-  // the plain array that is 'children'.
-  const obj = csstree.toPlainObject(ast)
-  obj.children = cleanChildren(obj.children, keyframename => {
-    return activeAnimationNames.has(keyframename.toLowerCase())
-  })
-  return csstree.fromPlainObject(obj)
 }
 
 /**
  *
  * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean }} options
- * @return Promise<{ finalCss: string, stylesheetAstObjects: any, stylesheetContents: string }>
+ * @return Promise<{ finalCss: string, stylesheetContents: string }>
  */
 const minimalcss = async options => {
   const { urls } = options
@@ -76,7 +51,7 @@ const minimalcss = async options => {
   // just a cli app.
   const browser = options.browser || (await puppeteer.launch({}))
 
-  const stylesheetAstObjects = {}
+  const stylesheetAst = {}
   const stylesheetContents = {}
   const doms = []
   const allHrefs = new Set()
@@ -111,17 +86,17 @@ const minimalcss = async options => {
         /\.(png|jpg|jpeg|gif|webp)$/.test(request.url.split('?')[0])
       ) {
         request.abort()
-      } else if (stylesheetAstObjects[request.url]) {
+      } else if (stylesheetAst[request.url]) {
         // no point downloading this again
         request.abort()
       } else if (options.skippable && options.skippable(request)) {
         // If the URL of the request that got skipped is a CSS file
-        // not having it in stylesheetAstObjects is going to cause a
+        // not having it in stylesheetAst is going to cause a
         // problem later when we loop through all <link ref="stylesheet">
         // tags.
         // So put in an empty (but not falsy!) object for this URL.
         if (request.url.match(/\.css/i)) {
-          stylesheetAstObjects[request.url] = {}
+          stylesheetAst[request.url] = {}
           stylesheetContents[request.url] = ''
         }
         request.abort()
@@ -139,10 +114,7 @@ const minimalcss = async options => {
       }
       if (ct.indexOf('text/css') > -1 || /\.css$/i.test(responseUrl)) {
         response.text().then(text => {
-          const ast = csstree.parse(text, {
-            parseValue: true,
-            parseRulePrelude: false
-          })
+          const ast = csstree.parse(text)
           csstree.walk(ast, node => {
             if (node.type === 'Url') {
               let value = node.value
@@ -169,7 +141,7 @@ const minimalcss = async options => {
               value.value = path
             }
           })
-          stylesheetAstObjects[responseUrl] = csstree.toPlainObject(ast)
+          stylesheetAst[responseUrl] = ast
           stylesheetContents[responseUrl] = text
         })
       }
@@ -227,11 +199,11 @@ const minimalcss = async options => {
           !link.href.toLowerCase().startsWith('blob:') &&
           link.media !== 'print'
         ) {
-          // if (!stylesheetAstObjects[link.href]) {
-          //   throw new Error(`${link.href} not in stylesheetAstObjects!`)
+          // if (!stylesheetAst[link.href]) {
+          //   throw new Error(`${link.href} not in stylesheetAst!`)
           // }
-          // if (!Object.keys(stylesheetAstObjects[link.href]).length) {
-          //   // If the 'stylesheetAstObjects[link.href]' thing is an
+          // if (!Object.keys(stylesheetAst[link.href]).length) {
+          //   // If the 'stylesheetAst[link.href]' thing is an
           //   // empty object, simply skip this link.
           //   return
           // }
@@ -259,97 +231,88 @@ const minimalcss = async options => {
 
   // Now, let's loop over ALL links and process their ASTs compared to
   // the DOMs.
-  const objsCleaned = {}
   const decisionsCache = {}
-  const DEAD_OBVIOUS = new Set(['*', 'body', 'html'])
-  allHrefs.forEach(href => {
-    const ast = stylesheetAstObjects[href]
-    const clean = (children, callback) => {
-      return children.filter(child => {
-        if (child.type === 'Rule') {
-          const values = child.prelude.value.split(',').map(x => x.trim())
-          const keepValues = values.filter(selectorString => {
-            if (decisionsCache[selectorString] !== undefined) {
-              return decisionsCache[selectorString]
-            }
-            const keep = callback(selectorString)
-            decisionsCache[selectorString] = keep
-            return keep
-          })
-          if (keepValues.length) {
-            // re-write the selector value
-            child.prelude.value = keepValues.join(', ')
-            return true
-          } else {
-            return false
-          }
-          // } else if (
-          //   child.type === 'Atrule' &&
-          //   child.prelude &&
-          //   child.expression.type === 'MediaQueryList'
-          // ) {
-        } else if (child.type === 'Atrule' && child.name === 'media') {
-          // recurse
-          child.block.children = clean(child.block.children, callback)
-          return child.block.children.length > 0
-        } else {
-          // Things like comments
-          // console.log(child.type);
-          // console.dir(child)
+  const isSelectorMatchToAnyElement = selectorString => {
+    // Here's the crucial part. Decide whether to keep the selector
+    // Find at least 1 DOM that contains an object that matches
+    // this selector string.
+    return doms.some(dom => {
+      try {
+        return dom(selectorString).length > 0
+      } catch (ex) {
+        // Be conservative. If we can't understand the selector,
+        // best to leave it in.
+        if (debug) {
+          console.warn(selectorString, ex.toString())
         }
-        // The default is to keep it.
-        return true
-      })
-    }
-
-    ast.children = clean(ast.children, selectorString => {
-      // Here's the crucial part. Decide whether to keep the selector
-      if (DEAD_OBVIOUS.has(selectorString)) {
-        // low hanging fruit easy ones.
         return true
       }
-      // This changes things like `a.button:active` to `a.button`
-      const originalSelectorString = selectorString
-      selectorString = utils.reduceCSSSelector(originalSelectorString)
-      // Find at least 1 DOM that contains an object that matches
-      // this selector string.
-      return doms.some(dom => {
-        try {
-          return dom(selectorString).length > 0
-        } catch (ex) {
-          // Be conservative. If we can't understand the selector,
-          // best to leave it in.
-          if (debug) {
-            console.warn(selectorString, ex.toString())
-          }
-          return true
-        }
-      })
     })
-    objsCleaned[href] = ast
+  }
+  allHrefs.forEach(href => {
+    const ast = stylesheetAst[href]
+
+    csstree.walk(ast, {
+      visit: 'Rule',
+      enter: (node, item, list) => {
+        node.prelude.children.forEach((node, item, list) => {
+          // Translate selector's AST to a string and filter pseudos from it
+          // This changes things like `a.button:active` to `a.button`
+          const selectorString = utils.reduceCSSSelector(csstree.generate(node))
+          if (selectorString in decisionsCache === false) {
+            decisionsCache[selectorString] = isSelectorMatchToAnyElement(
+              selectorString
+            )
+          }
+          if (!decisionsCache[selectorString]) {
+            // delete selector from a list of selectors
+            list.remove(item)
+          }
+        })
+
+        if (node.prelude.children.isEmpty()) {
+          // delete rule from a list
+          list.remove(item)
+        }
+      }
+    })
   })
   // Every unique URL in every <link> tag has been checked.
-  const allCombinedCss = Object.keys(objsCleaned)
-    .map(cssUrl => {
-      return csstree.translate(csstree.fromPlainObject(objsCleaned[cssUrl]))
-    })
-    .join('\n')
+  const allCombinedAst = {
+    type: 'StyleSheet',
+    loc: null,
+    children: Object.keys(stylesheetAst).reduce(
+      (children, href) => children.appendList(stylesheetAst[href].children),
+      new csstree.List()
+    )
+  }
+
+  // Lift important comments (i.e. /*! comment */) up to the beginning
+  const comments = new csstree.List()
+  csstree.walk(allCombinedAst, {
+    visit: 'Comment',
+    enter: (node, item, list) => {
+      comments.append(list.remove(item))
+    }
+  })
+  allCombinedAst.children.prependList(comments)
 
   // Why not just allow the return of the "unminified" CSS (in case
   // some odd ball wants it)?
-  // Because, the 'allCombinedCss' is a string that concatenates multiple
-  // payloads of CSS. It only contains the selectors that are supposedly
+  // 'allCombinedAst' concatenates multiple payloads of CSS.
+  // It only contains the selectors that are supposedly
   // in the DOM. However it does contain *duplicate* selectors.
   // E.g. `p { color: blue; } p { font-weight: bold; }`
   // When ultimately, what was need is `p { color: blue; font-weight: bold}`.
   // The csso.minify() function will solve this, *and* whitespace minify
   // it too.
-  let finalCss = utils.collectImportantComments(allCombinedCss)
-  let csstreeAst = csstree.parse(csso.minify(finalCss).css)
-  csstreeAst = postProcessKeyframes(csstreeAst)
-  finalCss = csstree.translate(csstreeAst)
+  csso.compress(allCombinedAst)
+  postProcessKeyframes(allCombinedAst)
 
-  const returned = { finalCss, stylesheetAstObjects, stylesheetContents }
+  const returned = {
+    finalCss: csstree.generate(allCombinedAst),
+    stylesheetContents
+  }
   return Promise.resolve(returned)
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -291,7 +291,7 @@ const minimalcss = async options => {
   const comments = new csstree.List()
   csstree.walk(allCombinedAst, {
     visit: 'Comment',
-    enter: (node, item, list) => {
+    enter: (_node, item, list) => {
       comments.append(list.remove(item))
     }
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,16 +192,9 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-tree@1.0.0-alpha.26:
-  version "1.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.26.tgz#690bee3458fb5b6b7000553983c8c30876da0b3e"
-  dependencies:
-    mdn-data "^1.0.0"
-    source-map "^0.5.3"
-
-css-tree@1.0.0-alpha25:
-  version "1.0.0-alpha25"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha25.tgz#1bbfabfbf6eeef4f01d9108ff2edd0be2fe35597"
+css-tree@1.0.0-alpha.27:
+  version "1.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.27.tgz#f211526909c7dc940843d83b9376ed98ddb8de47"
   dependencies:
     mdn-data "^1.0.0"
     source-map "^0.5.3"
@@ -210,11 +203,11 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
-csso@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-3.4.0.tgz#57b27ef553cccbf5aa964c641748641e9af113f3"
+csso@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-3.5.0.tgz#acdbba5719e2c87bc801eadc032764b2e4b9d4e7"
   dependencies:
-    css-tree "1.0.0-alpha25"
+    css-tree "1.0.0-alpha.27"
 
 date-fns@^1.27.2:
   version "1.29.0"


### PR DESCRIPTION
I reworked main program to more effective use of CSSTree. There are some comments on changes:

## parse
- I removed `parseRulePrelude: false` since parsed selectors are suitable for future manipulation and needed for CSSO
- Also I remove `parseValue: true` – it's default setting

## clean rules
- No need to remove empty `@media`, since CSSO does it later
- Therefore at the moment we need walk through `Rule` nodes only
- It's better to use `csstree.walk()` for a traversal through AST, otherwise you can miss some nodes, e.g. you missed that `Rule` nodes can be inside `@supports` and `@document` blocks
- `objsCleaned` is not needed since AST doesn't copy on walk, so `objsCleaned` and `stylesheetAstObjects` will contain the same trees. If you want keep original tree you need make its copy with `csstree.clone()`. For now I removed `objsCleaned`
- `DEAD_OBVIOUS` is not needed since listed selectors are quite rare, so no benefits here (I removed it)
- `selectorAsString.split(',')` is common mistake, doing that you may break the selector (e.g. `a:not(b, c) b[name="Hello, world!"]`). That's why better to parse selectors by CSSTree and then generate a CSS string from those nodes (i.e. `Selector` nodes)
- `utils.reduceCSSSelector()` does wrong things. Yep, you can remove pseudos classes like `:hover`, `:focus` and pseudo elements from a selector, but there are pseudos like `:not()`, `:empty`, `:nth-child()` etc that change the meaning of selector. Another problem that part of selector after any pseudo is cutting, e.g. `"a:hover img" -> "a"` so if there is no any `img` inside `a` the rule is still preserved. On the one hand, that's not a big dial, because you just left more rules that needed. On the other hand, this tool tries extract as minimal CSS as possible, so I think it should be fixed. Unfortunately, this is a complex problem so I left it as is at the moment. I let you know, when I found a better solution.
- One more benefit of selector string generation from AST: it performs a normalization of white spaces and comments removal. So it can reduces `decisionsCache` hit miss. But truly speaking, duplication of selectors is quite rare
- Therefore I moved `utils.reduceCSSSelector()` before cache check, so `a`, `a:hover`, `a:visited` etc will share a decision. Before the changes all of those selectors had its own decision results. So now requests count to DOM is reduced.
- No need to assembly a rule prelude back, we just pass through a selector list and remove unnecessary selectors from it. If a prelude become empty then remove a rule from AST.

## allCombinedCss
- `csstree.generate()` has a support for children as arrays (since alpha.27), so `fromPlainObject()` is not needed anymore. But that's not the case because I remove `toPlainObject()` before ;) Anyway, even if it left that doesn't break anything, just do nothing with AST
- Instead of all CSS concat we can join it to a single StyleSheet

## collectImportantComments
- We can lift up comments to the beginning using AST, beside turn AST into a string and use RegExps since it isn't robust. As you can see later, we should keep AST as long as possible to avoid unnecessary translate/parse rounds, because it leads to unwanted CPU and memory consumption

## minify
- CSSO can take CSSTree's AST, since uses it under the hood – so I just passed AST to it and escaped one more `parse`

## keyframes
- I rewrote this part to use power of CSSTree :) Btw, animation name can be at any position in a value and also it can be a string (i.e. quoted value). So your approach didn't work for many cases.

## result
- I removed `stylesheetAst` from the result since it's unclear what you want to get: final AST or original AST. In case you need second one or both, you need make a copy of AST before transformation. But it will take a time and a memory