### PR TITLE
control waitUntil from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Switching to wait for [`networkidle0`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options)
   instead to allow the page slightly more time to finish more XHR and static
-  resources.
+  resources. [pull#87](https://github.com/peterbe/minimalcss/pull/87)
 
 # 0.6.2
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ key is `urls`. Other optional options are:
 * `browser` - Instance of a [Browser](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser), which will be used instead of launching another one.
 * `userAgent` - specific user agent to use (string)
 * `viewport` - viewport object as specified in [page.setViewport](https://github.com/GoogleChrome/puppeteer/blob/v1.0.0/docs/api.md#pagesetviewportviewport)
+* `waitUntil` - Array of strings valid to send to [page.goto](https://github.com/GoogleChrome/puppeteer/blob/v1.0.0/docs/api.md#pagegotourl-options).
+  Defaults to `['domcontentloaded', 'networkidle0']`. It can also be just a string.
 
 ## Warnings
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ key is `urls`. Other optional options are:
 * `userAgent` - specific user agent to use (string)
 * `viewport` - viewport object as specified in [page.setViewport](https://github.com/GoogleChrome/puppeteer/blob/v1.0.0/docs/api.md#pagesetviewportviewport)
 * `waitUntil` - Array of strings valid to send to [page.goto](https://github.com/GoogleChrome/puppeteer/blob/v1.0.0/docs/api.md#pagegotourl-options).
-  Defaults to `['domcontentloaded', 'networkidle0']`. It can also be just a string.
+  Defaults to `['domcontentloaded', 'networkidle0']`. It can also be just
+  a string. `'load'` is not a valid option.
 
 ## Warnings
 

--- a/bin/minimalcss.js
+++ b/bin/minimalcss.js
@@ -21,7 +21,7 @@ const argv = minimist(args, {
     'loadimages',
     'withoutjavascript'
   ],
-  string: ['output', 'skip', 'viewport'],
+  string: ['output', 'skip', 'viewport', 'waituntil'],
   default: {
     // color: true,
     // "ignore-path": ".prettierignore"
@@ -57,6 +57,7 @@ if (argv['help']) {
       'then with. This disables the load without JavaScript.\n' +
       '  --skip                        String to match in URL to ignore download. Repeatable. E.g. --skip google-analyics.com\n' +
       '  --viewport                    JSON string that gets converted into valid parameter to `page.setViewport()`\n' +
+      "  --waituntil                   Comma separated string to use in `page.goto()` options (defaults to 'domcontentloaded,networkidle0')\n" +
       '  --version or -v               Print minimalcss version.\n' +
       ''
   )
@@ -86,6 +87,24 @@ const parseViewport = asString => {
   }
 }
 
+const parseWaitUntil = value => {
+  if (!value) {
+    return null
+  }
+  const validStrings = [
+    'load',
+    'domcontentloaded',
+    'networkidle0',
+    'networkidle2'
+  ]
+  return value.split(',').map(x => {
+    if (!validStrings.includes(x.trim())) {
+      throw new Error(`${x} is not a valid 'waitUntil' option`)
+    }
+    return x.trim()
+  })
+}
+
 const options = {
   urls: urls,
   debug: argv['debug'],
@@ -101,7 +120,8 @@ const options = {
     }
     return skips.some(skip => !!request.url().match(skip))
   },
-  viewport: parseViewport(argv['viewport'])
+  viewport: parseViewport(argv['viewport']),
+  waitUntil: parseWaitUntil(argv['waituntil'])
 }
 
 const start = Date.now()

--- a/bin/minimalcss.js
+++ b/bin/minimalcss.js
@@ -91,15 +91,11 @@ const parseWaitUntil = value => {
   if (!value) {
     return null
   }
-  const validStrings = [
-    'load',
-    'domcontentloaded',
-    'networkidle0',
-    'networkidle2'
-  ]
+  const validStrings = ['domcontentloaded', 'networkidle0', 'networkidle2']
   return value.split(',').map(x => {
     if (!validStrings.includes(x.trim())) {
-      throw new Error(`${x} is not a valid 'waitUntil' option`)
+      console.error(`${x} is not a valid 'waitUntil' option.`)
+      process.exit(4)
     }
     return x.trim()
   })

--- a/tests/examples/slowcss.html
+++ b/tests/examples/slowcss.html
@@ -1,6 +1,8 @@
 <html>
   <head>
-  <link rel=stylesheet href=http://httpbin.org/delay/1>
+    <!-- The content of the stylesheet URL here doesn't matter.
+    What matters is that it's slow to respond. -->
+    <link rel=stylesheet href=http://httpbin.org/delay/2>
   </head>
   <body>
     <p>The CSS on this page is slow!</p>

--- a/tests/examples/slowcss.html
+++ b/tests/examples/slowcss.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+  <link rel=stylesheet href=http://httpbin.org/delay/1>
+  </head>
+  <body>
+    <p>The CSS on this page is slow!</p>
+  </body>
+</html>

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -9,11 +9,10 @@ fastify.register(require('fastify-static'), {
 
 let browser
 
-const runMinimalcss = path => {
-  return minimalcss.minimize({
-    browser,
-    urls: [`http://localhost:3000/${path}.html`]
-  })
+const runMinimalcss = (path, options = {}) => {
+  options.browser = browser
+  options.urls = [`http://localhost:3000/${path}.html`]
+  return minimalcss.minimize(options)
 }
 
 beforeAll(async () => {
@@ -46,6 +45,19 @@ test('handles JS errors', async () => {
     await runMinimalcss('jserror')
   } catch (e) {
     expect(e.message).toMatch('Error: unhandled')
+  }
+})
+
+test('handles impatient CSS downloads', async () => {
+  expect.assertions(1)
+  try {
+    await runMinimalcss('slowcss', {
+      // The most impatient option. The `slowcss.html` fixture uses
+      // a <link> href that takes a whole second to download.
+      waitUntil: 'load'
+    })
+  } catch (e) {
+    expect(e.message).toMatch('Found stylesheets that failed to download')
   }
 })
 

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -53,8 +53,8 @@ test('handles impatient CSS downloads', async () => {
   try {
     await runMinimalcss('slowcss', {
       // The most impatient option. The `slowcss.html` fixture uses
-      // a <link> href that takes a whole second to download.
-      waitUntil: 'load'
+      // a <link> href that takes 2 whole seconds to download.
+      waitUntil: 'domcontentloaded'
     })
   } catch (e) {
     expect(e.message).toMatch('Found stylesheets that failed to download')


### PR DESCRIPTION
The diff is big. It kinda escalated. First I made it possible to control the `waitUntil` option from the cli. Then I tested it with a fat page and got weird errors. 
```sh
$ ./bin/minimalcss.js -d --waituntil load https://www.quantamagazine.org/what-makes-the-hardest-equations-in-physics-so-difficult-20180116/
TypeError: Cannot read property 'type' of undefined
    at Object.<anonymous> (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/css-tree/lib/walker/create.js:12:17)
    at walkNode (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/css-tree/lib/walker/create.js:155:19)
    at Object.walk (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/css-tree/lib/walker/create.js:214:9)
    at allHrefs.forEach.href (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:375:13)
    at Set.forEach (native)
    at Object.minimalcss [as run] (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:372:12)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```
The assumption is that when it comes time to check every found `<link href>` we assume that they have *all* been downloaded and parsed. If you run `minimalcss` "too impatiently" that breaks. So I added a check. 
Perhaps the error message should be a bit more user-friendly and explain "You might have to set a different 'waitUntil' to give the external stylesheets more time to download."
