### PR TITLE
remove collectImportantComments

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,35 +1,4 @@
 /**
- * Take call "important comments" and extract them all to the
- * beginning of the CSS string.
- * This makes it possible to merge when minifying across blocks of CSS.
- * For example, if you have (ignore the escaping for the sake of demonstration):
- *
- *   /*! important 1 *\/
- *   p { color: red; }
- *   /*! important 2 *\/
- *   p { background-color: red; }
- *
- * You can then instead get:
- *
- *   /*! important 1 *\/
- *   /*! important 2 *\/
- *   p { color: red; background-color: red; }
- *
- * @param {string} css
- * @return {string}
- */
-const collectImportantComments = css => {
-  const once = new Set()
-  let cleaned = css.replace(/\/\*\![\s\S]*?\*\/\n*/gm, match => {
-    once.add(match)
-    return ''
-  })
-  let combined = Array.from(once)
-  combined.push(cleaned)
-  return combined.join('\n')
-}
-
-/**
  * Reduce a CSS selector to be without any pseudo class parts.
  * For example, from `a:hover` return `a`. And from `input::-moz-focus-inner`
  * to `input`.
@@ -61,4 +30,4 @@ const unquoteString = string => {
   return string
 }
 
-module.exports = { collectImportantComments, reduceCSSSelector, unquoteString }
+module.exports = { reduceCSSSelector, unquoteString }


### PR DESCRIPTION
When @lahmatiy rewrote much of the inner stuff to use `csstree` (properly instead) we stopped to depend on this utility function. 