### PR TITLE
remove print media at rules

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -36,12 +36,19 @@ const postProcessOptimize = ast => {
       .map(entry => csstree.generate(entry.nodes.first()))
   )
 
-  // This is the function we use to filter @keyframes atrules out.
+  // This is the function we use to filter @keyframes atrules out,
+  // if its name is not actively used.
+  // It also filters out all `@media print` atrules.
   csstree.walk(ast, {
     visit: 'Atrule',
     enter: (node, item, list) => {
-      if (csstree.keyword(node.name).basename === 'keyframes') {
+      const basename = csstree.keyword(node.name).basename
+      if (basename === 'keyframes') {
         if (!activeAnimationNames.has(csstree.generate(node.prelude))) {
+          list.remove(item)
+        }
+      } else if (basename === 'media') {
+        if (csstree.generate(node.prelude) === 'print') {
           list.remove(item)
         }
       }

--- a/tests/examples/media-queries-print.css
+++ b/tests/examples/media-queries-print.css
@@ -1,0 +1,3 @@
+@media print {
+  a { color: red }
+}

--- a/tests/examples/media-queries-print.html
+++ b/tests/examples/media-queries-print.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link href="media-queries-print.css" rel="stylesheet">
+  </head>
+  <body>
+    <a href="">test</a>
+  </body>
+</html>

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -63,3 +63,9 @@ test('handles 404 CSS file', async () => {
     expect(e.message).toMatch('404 on')
   }
 })
+
+test('media queries print removed', async () => {
+  const result = ''
+  const { finalCss } = await runMinimalcss('media-queries-print')
+  expect(finalCss).toEqual(result)
+})


### PR DESCRIPTION
I took the fixture you started in https://github.com/peterbe/minimalcss/pull/88 and copied it into this. Then I made the necessary code change so it actually makes the minimal CSS remove the `@media print {...}` block. 