### PR TITLE
tidy-up for redirect and 0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.3
+
+* Redirects, both of external style sheets and other URLs is now correctly
+  followed. [pull#106](https://github.com/peterbe/minimalcss/pull/106)
+
 * Remove `@media print` rules. [pull#101](https://github.com/peterbe/minimalcss/pull/101)
 
 * Switching to wait for [`networkidle0`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options)

--- a/src/run.js
+++ b/src/run.js
@@ -190,7 +190,7 @@ const processPage = ({
           // If the 'Location' header points to a relative URL,
           // convert it to an absolute URL.
           // If it already was an absolute URL, it stays like that.
-          const redirectsTo = new URL(
+          const redirectsTo = new url.URL(
             response.headers().location,
             responseUrl
           ).toString()


### PR DESCRIPTION
So I was just cleaning up and I went back to the original issue to make sure it worked. It didn't:
```sh
▶ node --trace-warnings bin/minimalcss.js -d -o /tmp/bootstrap.before.css http://blog.getbootstrap.com/
(node:95998) ReferenceError: URL is not defined
    at Page.page.on.response (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:196:13)
    at emitOne (events.js:115:13)
    at Page.emit (events.js:210:7)
    at NetworkManager.Page._networkManager.on.event (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/Page.js:94:75)
    at emitOne (events.js:115:13)
    at NetworkManager.emit (events.js:210:7)
    at NetworkManager._handleRequestRedirect (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:182:10)
    at NetworkManager._onRequestIntercepted (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:155:14)
    at emitOne (events.js:115:13)
    at CDPSession.emit (events.js:210:7)
(node:95998) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
    at emitWarning (internal/process/promises.js:69:15)
    at emitPendingUnhandledRejections (internal/process/promises.js:86:11)
    at runMicrotasksCallback (internal/process/next_tick.js:124:9)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
(node:95998) ReferenceError: URL is not defined
    at Page.page.on.response (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:196:13)
    at emitOne (events.js:115:13)
    at Page.emit (events.js:210:7)
    at NetworkManager.Page._networkManager.on.event (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/Page.js:94:75)
    at emitOne (events.js:115:13)
    at NetworkManager.emit (events.js:210:7)
    at NetworkManager._handleRequestRedirect (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:182:10)
    at NetworkManager._onRequestIntercepted (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:155:14)
    at emitOne (events.js:115:13)
    at CDPSession.emit (events.js:210:7)
(node:95998) ReferenceError: URL is not defined
    at Page.page.on.response (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:196:13)
    at emitOne (events.js:115:13)
    at Page.emit (events.js:210:7)
    at NetworkManager.Page._networkManager.on.event (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/Page.js:94:75)
    at emitOne (events.js:115:13)
    at NetworkManager.emit (events.js:210:7)
    at NetworkManager._handleRequestRedirect (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:182:10)
    at NetworkManager._onRequestIntercepted (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:155:14)
    at emitOne (events.js:115:13)
    at CDPSession.emit (events.js:210:7)
(node:95998) ReferenceError: URL is not defined
    at Page.page.on.response (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:196:13)
    at emitOne (events.js:115:13)
    at Page.emit (events.js:210:7)
    at NetworkManager.Page._networkManager.on.event (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/Page.js:94:75)
    at emitOne (events.js:115:13)
    at NetworkManager.emit (events.js:210:7)
    at NetworkManager._handleRequestRedirect (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:182:10)
    at NetworkManager._onRequestIntercepted (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:155:14)
    at emitOne (events.js:115:13)
    at CDPSession.emit (events.js:210:7)
(node:95998) ReferenceError: URL is not defined
    at Page.page.on.response (/Users/peterbe/dev/JAVASCRIPT/minimalcss/src/run.js:196:13)
    at emitOne (events.js:115:13)
    at Page.emit (events.js:210:7)
    at NetworkManager.Page._networkManager.on.event (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/Page.js:94:75)
    at emitOne (events.js:115:13)
    at NetworkManager.emit (events.js:210:7)
    at NetworkManager._handleRequestRedirect (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:182:10)
    at NetworkManager._onRequestIntercepted (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NetworkManager.js:155:14)
    at emitOne (events.js:115:13)
    at CDPSession.emit (events.js:210:7)
Error: Navigation Timeout Exceeded: 30000ms exceeded
    at Promise.then (/Users/peterbe/dev/JAVASCRIPT/minimalcss/node_modules/puppeteer/lib/NavigatorWatcher.js:71:21)
    at <anonymous>

```

So rather sloppily I included a quick fix here. 