### PR TITLE
test that order matters

### DIFF
--- a/tests/examples/inheritance-first.css
+++ b/tests/examples/inheritance-first.css
@@ -1,0 +1,4 @@
+p {
+  font-size: 10px;
+  color: violet;
+}

--- a/tests/examples/inheritance-second.css
+++ b/tests/examples/inheritance-second.css
@@ -1,0 +1,4 @@
+p {
+  font-size: 16px;
+  font-style: italic;
+}

--- a/tests/examples/inheritance.html
+++ b/tests/examples/inheritance.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link href="inheritance-first.css" rel="stylesheet">
+    <link href="inheritance-second.css" rel="stylesheet">
+  </head>
+  <body>
+    <p>Only a p tag here.</p>
+  </body>
+</html>

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -152,3 +152,11 @@ test("deliberately skipped .css shouldn't error", async () => {
   })
   expect(finalCss).toEqual('p{color:brown}')
 })
+
+test('order matters in multiple style sheets', async () => {
+  // In inheritance.html it references two .css files. The
+  // second one overrides the first one. But it's not a 100% overlap,
+  // as the first one has some rules of its own.
+  const { finalCss } = await runMinimalcss('inheritance')
+  expect(finalCss).toEqual('p{color:violet;font-size:16px;font-style:italic}')
+})


### PR DESCRIPTION
To make this work, nothing had to be done to the code. But it feels like such an important feature that I didn't want it to go without a good test. 

It basically confirms that:
```css
p {
  font-size: 10px;
  color: violet;
}
```
**∪**
```css
p {
  font-size: 16px;
  font-style: italic;
}
```
**=**
```css
p {
  color: violet;
  font-size: 16px;
  font-style: italic;
}
```

This is what you get when you open `localhost:8080/inheritance.html` in the browser too. 