### PR TITLE
Throw error if invalid CSS is encountered

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -456,6 +456,14 @@ const minimalcss = async options => {
           return;
         }
 
+        if (!node.prelude.children) {
+          throw new Error(
+            `Invalid CSS found while evaluating ${href}: "${
+              node.prelude.value
+            }"`
+          );
+        }
+
         node.prelude.children.forEach((node, item, list) => {
           // Translate selector's AST to a string and filter pseudos from it
           // This changes things like `a.button:active` to `a.button`

--- a/tests/examples/invalid-css.css
+++ b/tests/examples/invalid-css.css
@@ -1,0 +1,3 @@
+$body {
+  color: violet;
+}

--- a/tests/examples/invalid-css.html
+++ b/tests/examples/invalid-css.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <link href="invalid-css.css" rel=stylesheet>
+</head>
+
+<body>
+  <p>Invalid css</p>
+</body>
+
+</html>

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -145,6 +145,20 @@ test('form elements', async () => {
   expect(finalCss).toMatch('option:selected');
 });
 
+test.only('invalid css', async () => {
+  expect.assertions(1);
+
+  try {
+    await runMinimalcss('invalid-css');
+  } catch (error) {
+    const expectedUrl = 'http://localhost:3000/invalid-css.css';
+    const expectedInvalidCSS = '$body';
+    expect(error.toString()).toMatch(
+      `Invalid CSS found while evaluating ${expectedUrl}: "${expectedInvalidCSS}"`
+    );
+  }
+});
+
 test('handles 307 CSS file', async () => {
   const { finalCss } = await runMinimalcss('307css');
   expect(finalCss).toEqual('p{color:violet}');


### PR DESCRIPTION
This throws an error if invalid CSS is found during `csstree.walk`. 

I couldn't find a nice way to output the line or surrounding nodes to help the dev.