### PR TITLE
ignoreJSErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ key is `urls`. Other optional options are:
 * `debug` - all console logging during page rendering are included in the
   stdout. Also, any malformed selector that cause errors in `document.querySelector`
   will be raised as new errors.
-* `skippable` - function wich takes
+* `skippable` - function which takes
   [request](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-request)
   as an argument and returns boolean. If it returns true then given request
   will be aborted (skipped). Can be used to block requests to Google Analytics
@@ -176,7 +176,10 @@ key is `urls`. Other optional options are:
   of strings for headless Chrome](https://peter.sh/experiments/chromium-command-line-switches/).
 * `cssoOptions` - CSSO compress function [options](https://github.com/css/csso#compressast-options)
 * `timeout` - Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
-* `ignoreCSSErrors` - By default, any CSS parsing error throws an error in minimalcss. If you know it's safe to ignore (for example, third-party CSS resources), set this to true.
+* `ignoreCSSErrors` - By default, any CSS parsing error throws an error in `minimalcss`. If you know it's safe to ignore (for example, third-party CSS resources), set this to true.
+* `ignoreJSErrors` - By default, any JavaScript error encountered by puppeteer 
+will be thrown by `minimalcss`. If you know it's safe to ignore errors (for example, on
+third-party webpages), set this to true.
 
 ## Warnings
 

--- a/src/run.js
+++ b/src/run.js
@@ -254,7 +254,11 @@ const processPage = ({
       });
 
       page.on('pageerror', error => {
-        safeReject(error);
+        if (options.ignoreJSErrors) {
+          console.warn(error);
+        } else {
+          safeReject(error);
+        }
       });
 
       let response;
@@ -339,7 +343,7 @@ const processPage = ({
 
 /**
  *
- * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean }} options
+ * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean }} options
  * @return Promise<{ finalCss: string, stylesheetContents: { [key: string]: string } }>
  */
 const minimalcss = async options => {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -166,6 +166,13 @@ test('ignoreCSSErrors', async () => {
   expect(finalCss).toEqual('');
 });
 
+test('ignoreJSErrors', async () => {
+  const { finalCss } = await runMinimalcss('jserror', {
+    ignoreJSErrors: true
+  });
+  expect(finalCss).toEqual('');
+});
+
 test('handles 307 CSS file', async () => {
   const { finalCss } = await runMinimalcss('307css');
   expect(finalCss).toEqual('p{color:violet}');


### PR DESCRIPTION
Aside from tests and documentation, this should be the only change needed.

Camel-cased `ignoreJsErrors` (and `ignoreCssErrors`) might be more in keeping with the [style guide](https://github.com/peterbe/minimalcss/blob/master/CONTRIBUTING.md#style-guide).

https://github.com/peterbe/minimalcss/pull/249