### PR TITLE
parse style tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,11 @@ key is `urls`. Other optional options are:
   of strings for headless Chrome](https://peter.sh/experiments/chromium-command-line-switches/).
 * `cssoOptions` - CSSO compress function [options](https://github.com/css/csso#compressast-options)
 * `timeout` - Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
-* `ignoreCSSErrors` - By default, any CSS parsing error throws an error in `minimalcss`. If you know it's safe to ignore (for example, third-party CSS resources), set this to true.
+* `ignoreCSSErrors` - By default, any CSS parsing error throws an error in `minimalcss`. If you know it's safe to ignore (for example, third-party CSS resources), set this to `true`.
 * `ignoreJSErrors` - By default, any JavaScript error encountered by puppeteer 
 will be thrown by `minimalcss`. If you know it's safe to ignore errors (for example, on
-third-party webpages), set this to true.
+third-party webpages), set this to `true`.
+* `styletags` - If set to `true`, on-page `<style>` tags are parsed along with external stylesheets. By default, only external stylesheets are parsed.
 
 ## Warnings
 

--- a/bin/minimalcss.js
+++ b/bin/minimalcss.js
@@ -17,6 +17,7 @@ const argv = minimist(args, {
     'verbose',
     'debug',
     'loadimages',
+    'styletags',
     'withoutjavascript',
     'nosandbox'
   ],
@@ -51,6 +52,7 @@ if (argv['help']) {
       '  --verbose                     Include a comment about the options and the date it was generated.\n' +
       '  --debug or -d                 Print all console logging during page rendering to stdout.\n' +
       '  --loadimages                  By default, all images are NOT downloaded. This reverses that.\n' +
+      '  --styletags                   By default, all <style> tags are ignored. This will include them.\n' +
       '  --withoutjavascript           The CSS is evaluated against the DOM twice, first with no JavaScript, ' +
       'then with. This disables the load without JavaScript.\n' +
       '  --skip                        String to match in URL to ignore download. Repeatable. E.g. --skip google-analyics.com\n' +

--- a/src/run.js
+++ b/src/run.js
@@ -315,34 +315,76 @@ const processPage = ({
         );
       }
       const evalWithJavascript = await page.evaluate(() => {
+        const html = document.documentElement.outerHTML;
         // The reason for NOT using a Set here is that that might not be
         // supported in ES5.
         const hrefs = [];
-        // Loop over all the 'link' elements in the document and
-        // for each, collect the URL of all the ones we're going to assess.
-        Array.from(document.querySelectorAll('link')).forEach(link => {
-          if (
-            link.href &&
-            (link.rel === 'stylesheet' ||
-              link.href.toLowerCase().endsWith('.css')) &&
-            !link.href.toLowerCase().startsWith('blob:') &&
-            link.media !== 'print' &&
-            !link.href.toLowerCase().startsWith('data:')
-          ) {
-            // Fragments are omitted from puppeteer's response.url(),
-            // so we need to strip them here, otherwise the hrefs
-            // won't always match when we check for missing ASTs.
-            hrefs.push(link.href.split('#')[0]);
+        const styles = [];
+        const isCssStyleTag = elem =>
+          elem.tagName === 'STYLE' &&
+          (!elem.type || elem.type.toLowerCase() === 'text/css');
+        const isStylesheetLink = elem =>
+          elem.tagName === 'LINK' &&
+          elem.href &&
+          (elem.rel.toLowerCase() === 'stylesheet' ||
+            elem.href.toLowerCase().endsWith('.css')) &&
+          !(
+            elem.href.toLowerCase().startsWith('data:') ||
+            elem.href.toLowerCase().startsWith('blob:') ||
+            elem.media.toLowerCase() === 'print'
+          );
+        // #fragments are omitted from puppeteer's response.url(), so
+        // we need to strip them from stylesheet links, otherwise the
+        // hrefs won't always match when we check for missing ASTs.
+        const defragment = href => href.split('#')[0];
+        const pageUrl = defragment(window.location.href);
+        // Create a unique identifier for each style tag by appending
+        // an xpath-like fragment to the page URL.  This allows us to
+        // preserve the relative ordering of external stylesheets and
+        // inline style tags.
+        const styleTagUri = () => `${pageUrl}#style[${styles.length}]`;
+        // Loop over all 'link' and 'style' elements in the document,
+        // in order of appearance. For each element, collect the URI
+        // of all the ones we're going to assess. For style elements,
+        // also extract each tag's content.
+        Array.from(document.querySelectorAll('link, style')).forEach(elem => {
+          if (isStylesheetLink(elem)) {
+            const href = defragment(elem.href);
+            hrefs.push(href);
+          } else if (isCssStyleTag(elem)) {
+            const href = styleTagUri();
+            const text = elem.innerHTML;
+            styles.push({ href, text });
+            hrefs.push(href);
           }
         });
-        return {
-          html: document.documentElement.outerHTML,
-          hrefs
-        };
+        return { html, hrefs, styles };
       });
 
       const htmlWithJavascript = evalWithJavascript.html;
       doms.push(cheerio.load(htmlWithJavascript));
+
+      if (options.styletags) {
+        // Parse each style tag as if it were an external stylesheet.
+        evalWithJavascript.styles.forEach(({ href, text }) => {
+          processStylesheet({
+            text,
+            pageUrl,
+            stylesheetAsts,
+            stylesheetContents,
+            responseUrl: href
+          });
+        });
+      } else {
+        // Remove each style tag URI from the list of hrefs.
+        evalWithJavascript.styles.forEach(({ href }) => {
+          evalWithJavascript.hrefs.splice(
+            evalWithJavascript.hrefs.indexOf(href),
+            1
+          );
+        });
+      }
+
       evalWithJavascript.hrefs.forEach(href => {
         // The order of allHrefs is important! That's what browsers do.
         // But we can't blindly using allHrefs.push() because the href
@@ -365,7 +407,7 @@ const processPage = ({
 
 /**
  *
- * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean }} options
+ * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean, styletags?: boolean }} options
  * @return Promise<{ finalCss: string, stylesheetContents: { [key: string]: string } }>
  */
 const minimalcss = async options => {

--- a/src/run.js
+++ b/src/run.js
@@ -188,6 +188,7 @@ const processPage = ({
 
     const debug = options.debug || false;
     const loadimages = options.loadimages || false;
+    const styletags = options.styletags || false;
     const withoutjavascript =
       options.withoutjavascript === undefined
         ? true
@@ -364,7 +365,7 @@ const processPage = ({
       const htmlWithJavascript = evalWithJavascript.html;
       doms.push(cheerio.load(htmlWithJavascript));
 
-      if (options.styletags) {
+      if (styletags) {
         // Parse each style tag as if it were an external stylesheet.
         evalWithJavascript.styles.forEach(({ href, text }) => {
           processStylesheet({

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -73,6 +73,13 @@ test('cares only about external CSS files', async () => {
   expect(finalCss).toEqual('.external{color:red}');
 });
 
+test('cares about style tags and external CSS files', async () => {
+  const { finalCss } = await runMinimalcss('css-in-js', {
+    styletags: true
+  });
+  expect(finalCss).toEqual('.cssinjs1,.external,.inline{color:red}');
+});
+
 test('handles 404 CSS file', async () => {
   expect.assertions(1);
   try {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -69,11 +69,22 @@ test('handles JS errors', async () => {
 });
 
 test('cares only about external CSS files', async () => {
+  // The css-in-js fixture has external stylesheets, <style> tags,
+  // and inline 'style' attributes, both present on the page and
+  // injected using JavaScript.
+  // This test asserts that selectors from <style> tags and
+  // inline 'style' attributes are NOT included in the final CSS.
   const { finalCss } = await runMinimalcss('css-in-js');
   expect(finalCss).toEqual('.external{color:red}');
 });
 
 test('cares about style tags and external CSS files', async () => {
+  // The css-in-js fixture has external stylesheets, <style> tags,
+  // and inline 'style' attributes, both present on the page and
+  // injected using JavaScript.
+  // This test asserts that selectors from stylesheets and <style>
+  // tags are both included in the final CSS, while selectors from
+  // inline 'style' attributes are NOT included.
   const { finalCss } = await runMinimalcss('css-in-js', {
     styletags: true
   });

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -83,7 +83,7 @@ test('cares about style tags and external CSS files', async () => {
   // and inline 'style' attributes, both present on the page and
   // injected using JavaScript.
   // This test asserts that selectors from stylesheets and <style>
-  // tags are both included in the final CSS, while selectors from
+  // tags are both included in the final CSS, while rules from
   // inline 'style' attributes are NOT included.
   const { finalCss } = await runMinimalcss('css-in-js', {
     styletags: true


### PR DESCRIPTION
- [x]  Adds `options.styletags` to parse any on-page `<style>` tags (in addition to external stylesheets).
- [x]  Processes style tag content exactly the same way as external stylesheet text.
- [x]  Preserves relative ordering of external stylesheets and on-page style tags.
- [x]  Includes `<style>` tags that were created/modified after page load.
- [x]  Does not consider any inline `style="..."` attributes.
- [ ]  Probably fixes https://github.com/peterbe/minimalcss/issues/114
