### PR TITLE
Disable Service Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ key is `urls`. Other optional options are:
 * `cssoOptions` - CSSO compress function [options](https://github.com/css/csso#compressast-options)
 * `timeout` - Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
 * `ignoreCSSErrors` - By default, any CSS parsing error throws an error in `minimalcss`. If you know it's safe to ignore (for example, third-party CSS resources), set this to `true`.
-* `ignoreJSErrors` - By default, any JavaScript error encountered by puppeteer 
+* `ignoreJSErrors` - By default, any JavaScript error encountered by puppeteer
 will be thrown by `minimalcss`. If you know it's safe to ignore errors (for example, on
 third-party webpages), set this to `true`.
 * `styletags` - If set to `true`, on-page `<style>` tags are parsed along with external stylesheets. By default, only external stylesheets are parsed.
+* `enableServiceWorkers` - By default all Service Workers are disabled. This option enables them as is.
 
 ## Warnings
 

--- a/bin/minimalcss.js
+++ b/bin/minimalcss.js
@@ -19,7 +19,8 @@ const argv = minimist(args, {
     'loadimages',
     'styletags',
     'withoutjavascript',
-    'nosandbox'
+    'nosandbox',
+    'enableserviceworkers'
   ],
   string: ['output', 'skip', 'viewport'],
   default: {
@@ -53,6 +54,7 @@ if (argv['help']) {
       '  --debug or -d                 Print all console logging during page rendering to stdout.\n' +
       '  --loadimages                  By default, all images are NOT downloaded. This reverses that.\n' +
       '  --styletags                   By default, all <style> tags are ignored. This will include them.\n' +
+      '  --enableserviceworkers        By default, use of Service Workers is disable. This flag enables them.\n' +
       '  --withoutjavascript           The CSS is evaluated against the DOM twice, first with no JavaScript, ' +
       'then with. This disables the load without JavaScript.\n' +
       '  --skip                        String to match in URL to ignore download. Repeatable. E.g. --skip google-analyics.com\n' +
@@ -105,7 +107,8 @@ const options = {
   viewport: parseViewport(argv['viewport']),
   puppeteerArgs: argv['nosandbox']
     ? ['--no-sandbox', '--disable-setuid-sandbox']
-    : []
+    : [],
+  enableServiceWorkers: argv['enableserviceworkers']
 };
 
 const start = Date.now();

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "csso": "~3.5.0",
     "filesize": "^3.5.11",
     "minimist": "^1.2.0",
-    "puppeteer": "^1.4.0"
+    "puppeteer": "^1.8.0"
   },
   "devDependencies": {
     "fastify": "1.11.2",

--- a/src/run.js
+++ b/src/run.js
@@ -408,14 +408,18 @@ const processPage = ({
 
 /**
  *
- * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean, styletags?: boolean }} options
+ * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean, styletags?: boolean, enableServiceWorkers?: boolean }} options
  * @return Promise<{ finalCss: string, stylesheetContents: { [key: string]: string } }>
  */
 const minimalcss = async options => {
   const { urls } = options;
   const debug = options.debug || false;
   const cssoOptions = options.cssoOptions || {};
+  const enableServiceWorkers = options.enableServiceWorkers || false;
   const puppeteerArgs = options.puppeteerArgs || [];
+  if (!enableServiceWorkers) {
+    puppeteerArgs.push('--enable-features=NetworkService');
+  }
   const browser =
     options.browser ||
     (await puppeteer.launch({
@@ -436,6 +440,9 @@ const minimalcss = async options => {
     for (let i = 0; i < urls.length; i++) {
       const pageUrl = urls[i];
       const page = await browser.newPage();
+      if (!enableServiceWorkers) {
+        await page._client.send('ServiceWorker.disable');
+      }
       try {
         await processPage({
           page,

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+concat-stream@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -1086,13 +1087,13 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^1.6.5:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
   dependencies:
-    concat-stream "1.6.0"
+    concat-stream "1.6.2"
     debug "2.6.9"
-    mkdirp "0.5.0"
+    mkdirp "0.5.1"
     yauzl "2.4.1"
 
 extsprintf@1.3.0:
@@ -1560,9 +1561,9 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz#7fbba856be8cd677986f42ebd3664f6317257887"
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
@@ -2480,13 +2481,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
-
-"mkdirp@>=0.5 0", mkdirp@^0.5.1:
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2908,18 +2903,18 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
-puppeteer@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.4.0.tgz#437f0f3450d76e437185c0bf06f446e80f184692"
+puppeteer@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.8.0.tgz#9e8bbd2f5448cc19cac220efc0512837104877ad"
   dependencies:
     debug "^3.1.0"
-    extract-zip "^1.6.5"
-    https-proxy-agent "^2.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
     mime "^2.0.3"
     progress "^2.0.0"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
-    ws "^3.0.0"
+    ws "^5.1.1"
 
 qs@~6.4.0:
   version "6.4.0"
@@ -3620,10 +3615,6 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -3774,20 +3765,18 @@ write-file-atomic@^2.1.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-ws@^3.0.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
 ws@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
+
+ws@^5.1.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fixes #223 

@stereobooster Do you know of a good way to test this? Perhaps it's not possible. Perhaps it's not particularly important. 

Also, [here's how it used to fail](https://github.com/peterbe/minimalcss/issues/223#issuecomment-419529682)

Now, when you run the same you get:

```bash
▶ node bin/minimalcss.js https://googlechrome.github.io/samples/service-worker/basic/
body{background-color:#fff;box-sizing:border-box;font-family:"Roboto","Helvetica","Arial",sans-serif}@media screen and (min-width:832px){body{width:800px;margin:0 auto}}h1{margin-bottom:-.3em}h3{margin-bottom:-.2em;margin-top:2em}.availability{margin-bottom:2em}.highlight{border-radius:.75em;border:1px solid #f0f0f0;display:block;margin:.5em;overflow-x:auto;padding:.5em}code{font-family:Inconsolata,Consolas,monospace}.k,.o{font-weight:700}.c1,.cm{color:#998;font-style:italic}.kd{font-weight:700}.nb{color:#0086b3}.mi{color:#099}.s1{color:#d14}#container{display:flex;flex-direction:row;flex-wrap:wrap;justify-content:space-around}li{margin-bottom:1em}
```

And if you're nuts and you like errors you can get them back:

```bash
▶ node bin/minimalcss.js --enableserviceworkers https://googlechrome.github.io/samples/service-worker/basic/
[Error: DOMException: Failed to register a ServiceWorker: No URL is associated with the caller's document.]
```
