### PR TITLE
Add whitelist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ will be thrown by `minimalcss`. If you know it's safe to ignore errors (for exam
 third-party webpages), set this to `true`.
 * `styletags` - If set to `true`, on-page `<style>` tags are parsed along with external stylesheets. By default, only external stylesheets are parsed.
 * `enableServiceWorkers` - By default all Service Workers are disabled. This option enables them as is.
+* `whitelist` - Array of css selectors that should be left in final CSS. RegExp patterns are supported (e.g. `['sidebar', icon-.*, .*-error]`).
 
 ## Warnings
 

--- a/src/run.js
+++ b/src/run.js
@@ -405,15 +405,18 @@ const processPage = ({
 
 /**
  *
- * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean, styletags?: boolean, enableServiceWorkers?: boolean, disableJavaScript?: boolean }} options
+ * @param {{ urls: Array<string>, debug: boolean, loadimages: boolean, skippable: function, browser: any, userAgent: string, withoutjavascript: boolean, viewport: any, puppeteerArgs: Array<string>, cssoOptions: Object, ignoreCSSErrors?: boolean, ignoreJSErrors?: boolean, styletags?: boolean, enableServiceWorkers?: boolean, disableJavaScript?: boolean, whitelist?: Array<string> }} options
  * @return Promise<{ finalCss: string, stylesheetContents: { [key: string]: string } }>
  */
 const minimalcss = async options => {
-  const { urls } = options;
+  const { urls, whitelist = [] } = options;
   const debug = options.debug || false;
   const cssoOptions = options.cssoOptions || {};
   const enableServiceWorkers = options.enableServiceWorkers || false;
   const puppeteerArgs = options.puppeteerArgs || [];
+  const isInWhiteList = selector =>
+    whitelist.some(rule => new RegExp(rule).test(selector));
+
   if (!enableServiceWorkers) {
     puppeteerArgs.push('--enable-features=NetworkService');
   }
@@ -498,6 +501,10 @@ const minimalcss = async options => {
     // Here's the crucial part. Decide whether to keep the selector
     // Find at least 1 DOM that contains an object that matches
     // this selector string.
+    if (isInWhiteList(selectorString)) {
+      return true;
+    }
+
     return doms.some(dom => {
       try {
         return dom(selectorString).length > 0;

--- a/tests/examples/whitelist-css.css
+++ b/tests/examples/whitelist-css.css
@@ -1,0 +1,15 @@
+.paragraph {
+	height: 100%;
+}
+
+.icon {
+	height: 100%;
+}
+
+.icon-arrow {
+	width: 10px;
+}
+
+.icon-search {
+	width: 20px;
+}

--- a/tests/examples/whitelist-css.css
+++ b/tests/examples/whitelist-css.css
@@ -10,6 +10,6 @@
 	width: 10px;
 }
 
-.icon-search {
+.icon-search, .not-icon-something {
 	width: 20px;
 }

--- a/tests/examples/whitelist-css.html
+++ b/tests/examples/whitelist-css.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Whitelist css selectors</title>
+  <link rel="stylesheet" href="./whitelist-css.css" />
+</head>
+<body>
+  <p>Only a p tag here.</p>
+</body>
+</html>

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -335,7 +335,7 @@ test('cares about static and dynamic styles when JavaScript enabled', async () =
 
 test('does not remove whitelisted css selectors', async () => {
   const { finalCss } = await runMinimalcss('whitelist-css', {
-    whitelist: ['icon-.*']
+    whitelist: ['\\.icon-.*']
   });
 
   expect(finalCss).toEqual('.icon-arrow{width:10px}.icon-search{width:20px}');

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -332,3 +332,11 @@ test('cares about static and dynamic styles when JavaScript enabled', async () =
 
   expect(finalCss).toEqual('.inline{color:red}');
 });
+
+test('does not remove whitelisted css selectors', async () => {
+  const { finalCss } = await runMinimalcss('whitelist-css', {
+    whitelist: ['icon-.*']
+  });
+
+  expect(finalCss).toEqual('.icon-arrow{width:10px}.icon-search{width:20px}');
+});


### PR DESCRIPTION
There are cases when the same webpage may look different depending on user language, experiment state, etc. It would be great if you could pass selectors whitelist to tell minimalcss that these selectors should be left in final CSS, no matter if they are not present at the time of puppeteer rendering.